### PR TITLE
UBERTC: Modify BoardConfig / reaper.dependencies to support building …

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -66,7 +66,7 @@ TARGET_KERNEL_APPEND_DTB := true
 TARGET_KERNEL_ARCH := arm64
 TARGET_KERNEL_HEADER_ARCH := arm64
 TARGET_KERNEL_SOURCE := kernel/oneplus/msm8994
-TARGET_KERNEL_CONFIG := oneplus2_defconfig
+TARGET_KERNEL_CONFIG := boeffla_defconfig
 TARGET_KERNEL_CROSS_COMPILE_PREFIX := aarch64-linux-android-
 
 # QCOM hardware

--- a/reaper.dependencies
+++ b/reaper.dependencies
@@ -6,9 +6,9 @@
   },
   {
     "remote":     "github",
-    "repository": "Seraph08/android_kernel_oneplus_msm8994",
+    "repository": "zanezam/boeffla-kernel-cm-oneplus2",
     "target_path": "kernel/oneplus/msm8994",
-    "revision":    "cm-14.1"
+    "revision":    "boeffla_cm14_aa64u494"
   },
   {
     "repository": "TheMuppets/proprietary_vendor_qcom_binaries",


### PR DESCRIPTION
…inline with zanezam's Boeffla Kernel repo - (https://github.com/zanezam/boeffla-kernel-cm-oneplus2/tree/boeffla_cm14_aa64u494).